### PR TITLE
🌀 Update Documentation to v1.4.5 and Document Binary Hardening

### DIFF
--- a/DOCS/README.md
+++ b/DOCS/README.md
@@ -113,7 +113,7 @@ Vibe C features a high-performance build system optimized for developer producti
 
 - **Parallel Compilation & Testing**: Uses a worker thread pool to compile multiple source files and run tests simultaneously (v1.4.4).
 - **Incremental Builds & Tests**: Automatically detects changed source, headers, and libraries to only recompile and rerun what is necessary.
-- **Binary Hardening**: Automatically applies comprehensive security hardening flags (`-fstack-protector-strong`, PIE, RELRO) to all compilation and linking steps (v1.4.5).
+- **Binary Hardening**: Automatically applies comprehensive security hardening flags (e.g., Stack Protector, PIE, RELRO) to all compilation and linking steps (v1.4.5).
 - **Optimized NO-OP**: Efficient `os.scandir` scanning, cached header `mtime`, and multi-pattern matching ensure that builds, tests, and security audits are high-performance (v1.4.4).
 
 ---

--- a/DOCS/README.md
+++ b/DOCS/README.md
@@ -113,6 +113,7 @@ Vibe C features a high-performance build system optimized for developer producti
 
 - **Parallel Compilation & Testing**: Uses a worker thread pool to compile multiple source files and run tests simultaneously (v1.4.4).
 - **Incremental Builds & Tests**: Automatically detects changed source, headers, and libraries to only recompile and rerun what is necessary.
+- **Binary Hardening**: Automatically applies comprehensive security hardening flags (`-fstack-protector-strong`, PIE, RELRO) to all compilation and linking steps (v1.4.5).
 - **Optimized NO-OP**: Efficient `os.scandir` scanning, cached header `mtime`, and multi-pattern matching ensure that builds, tests, and security audits are high-performance (v1.4.4).
 
 ---

--- a/DOCS/dev/README.md
+++ b/DOCS/dev/README.md
@@ -61,6 +61,14 @@ The `audit` command uses an optimized regex-based detection system to identify c
 ### Secure Utilities
 - **JSON Printing**: The `vibe_json.h` header includes a secure string printing helper that escapes double quotes and backslashes. This prevents JSON structure injection when printing user-provided strings from C applications (v1.4.4).
 
+### Binary Hardening
+Vibe C automatically applies security hardening flags during the compilation and linking phases to protect produced binaries against common exploits (v1.4.5):
+- **Stack Protection**: Uses `-fstack-protector-strong` to protect against stack buffer overflows.
+- **Fortify Source**: Enables `-D_FORTIFY_SOURCE=2` for additional run-time checks on standard library functions.
+- **Format String Security**: Enforces `-Wformat`, `-Wformat-security`, and `-Werror=format-security` to prevent format string vulnerabilities.
+- **ASLR (PIE)**: Compiles with `-fPIE` and links with `-pie` to ensure Position Independent Executables, enabling Address Space Layout Randomization.
+- **Linker Hardening**: Uses `-Wl,-z,relro,-z,now` for full Relocation Read-Only (RELRO) and immediate binding to protect the Global Offset Table (GOT).
+
 ## Contributing
 
 When making changes:

--- a/DOCS/dev/architecture.md
+++ b/DOCS/dev/architecture.md
@@ -36,6 +36,7 @@ A clean command-line interface built with `argparse`, and an optional interactiv
 - **Defense in Depth**: Combines input validation, safe subprocess management, and static analysis.
 - **Input Sanitization**: All CLI arguments and `vibe.json` values are validated against strict regex patterns before being used in file paths or commands.
 - **Sanitized Environments**: Ensures environment variables like `LD_LIBRARY_PATH` do not contain empty entries that could lead to library hijacking.
+- **Binary Hardening**: Automatically applies industry-standard security flags (`-fstack-protector-strong`, PIE, RELRO, etc.) to all compiled binaries and tests to mitigate memory corruption exploits (v1.4.5).
 
 ## Performance Engineering (Bolt ⚡)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vibe C Compiler (v1.4.4)
+# Vibe C Compiler (v1.4.5)
 
 The Vibe C Compiler is a project management and compilation suite designed to make C development easier and more intuitive than using GCC directly. It wraps around Clang to provide seamless cross-compilation support and project directory management.
 
@@ -8,6 +8,7 @@ The Vibe C Compiler is a project management and compilation suite designed to ma
 - **Simple CLI**: Easy commands like `init`, `build`, `run`, `test`, `install`, `uninstall`, `audit`, `update`, and `upgrade`.
 - **Fast Incremental Builds & Tests**: Optimized for speed with parallel execution, efficient NO-OP checks, and cached header scanning (v1.4.4).
 - **Parallel and Incremental Test Execution**: High-speed testing that only recompiles changed tests and runs them concurrently with pre-filtered NO-OP checks (v1.4.4).
+- **Binary Hardening**: Automatically applies security hardening flags (stack protection, PIE, RELRO) to all builds and tests (v1.4.5).
 - **Project Management**: Manages your project structure (`src/`, `build/`, `vibe.json`).
 - **Interactive Menu**: A simple TUI for those who prefer menus.
 - **High-Performance Scanning**: Uses `os.scandir` for rapid file discovery across all commands (v1.4.4).


### PR DESCRIPTION
This submission updates the Vibe C Compiler documentation to reflect the latest enhancements in version 1.4.5. 

Key changes include:
- Version bump from 1.4.4 to 1.4.5 in all relevant documentation files.
- Documentation of the new **Binary Hardening** feature, which automatically applies security flags like `-fstack-protector-strong`, PIE, and RELRO to builds and tests.
- Inclusion of the `upgrade` command alias in the CLI command list and quick start guide.
- Detailed technical explanation of the security hardening flags in the developer documentation (`DOCS/dev/README.md`) and architectural overview (`DOCS/dev/architecture.md`).

These updates ensure that the project's documentation remains accurate and provides users and developers with clear information about the latest security and usability features.

---
*PR created automatically by Jules for task [10355262137184231062](https://jules.google.com/task/10355262137184231062) started by @gtref*