### PR TITLE
🛡️ Sentinel: Harden vibe_print and vibe_error against format string vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -57,3 +57,8 @@
 **Vulnerability:** NULL pointer dereference and resource leaks in `vibe_thread_pool.h` due to unchecked `malloc` and `pthread_create` calls.
 **Learning:** Internal library headers, especially those providing concurrency or memory management primitives, must be audited for standard C safety patterns. Failing to handle resource exhaustion gracefully can lead to critical application failures.
 **Prevention:** Always check return values for memory allocation (`malloc`) and thread/synchronization primitives (`pthread_create`, `pthread_mutex_init`). Implement comprehensive cleanup (e.g., using `free` and `pthread_join`) if any part of a multi-stage initialization fails.
+
+## 2026-06-21 - Compile-time Format String Enforcement in Macros
+**Vulnerability:** Format string vulnerabilities in variadic macros that wrap `printf`-like functions.
+**Learning:** Macros that wrap `printf` can be hardened by using string literal concatenation (`"" __VA_ARGS__`) in the expansion. This trick leverages the C compiler's rule that only string literals can be concatenated this way, effectively forcing the first argument of the macro to be a literal and preventing insecure variable-based format strings at compile-time.
+**Prevention:** Always use the `"" __VA_ARGS__` pattern when defining macros that pass arguments directly to the format string position of `printf`, `fprintf`, or similar functions.

--- a/Jules/SENTINEL.md
+++ b/Jules/SENTINEL.md
@@ -1,5 +1,24 @@
 # Sentinel Security Log 🛡️
 
+## 2026-06-21 - Compile-time Format String Hardening
+
+### 🔍 Found
+- **Format String Vulnerabilities**: The `vibe_print` and `vibe_error` macros in `vibe_io.h` were simple wrappers around `printf` and `fprintf`. They allowed passing variables as the first argument, which could lead to format string vulnerabilities if those variables contained user-controlled data.
+- **Audit Tool Warnings**: The internal `vcc audit` tool flagged these macros as potential security risks but they remained unhardened in the core library.
+
+### 🎯 Impact
+- **Arbitrary Code Execution/Information Leakage**: An attacker could exploit a format string vulnerability to read from or write to arbitrary memory locations.
+- **Syntactic Bypass**: While the compiler flags `-Wformat-security` were enabled, some environments or older compilers might not enforce this, leaving applications vulnerable.
+
+### 🔧 Fix
+- **Hardened Macros**: Redefined `vibe_print` and `vibe_error` in `vibe/include/vibe_io.h` to use string literal concatenation: `#define vibe_print(...) printf("" __VA_ARGS__)`.
+- **Compile-time Enforcement**: This change forces the first argument of these macros to be a string literal. If a variable is passed as the first argument, the code will fail to compile, effectively eliminating the vulnerability at the source.
+
+### ✅ Verification
+- Verified that previously vulnerable code (passing a variable to `vibe_print`) now fails to compile with a clear error.
+- Verified that legitimate uses (passing a string literal format) continue to work as expected.
+- Ran full security audit and confirmed no regressions.
+
 ## 2026-06-20 - Thread Pool Robustness and Memory Safety
 
 ### 🔍 Found

--- a/vibe/include/vibe_io.h
+++ b/vibe/include/vibe_io.h
@@ -1,6 +1,6 @@
 #ifndef VIBE_IO_H
 #define VIBE_IO_H
 #include <stdio.h>
-#define vibe_print(...) printf(__VA_ARGS__)
-#define vibe_error(...) fprintf(stderr, __VA_ARGS__)
+#define vibe_print(...) printf("" __VA_ARGS__)
+#define vibe_error(...) fprintf(stderr, "" __VA_ARGS__)
 #endif

--- a/vibe/include/vibe_io.h
+++ b/vibe/include/vibe_io.h
@@ -1,6 +1,6 @@
 #ifndef VIBE_IO_H
 #define VIBE_IO_H
 #include <stdio.h>
-#define vibe_print(...) printf("" __VA_ARGS__)
-#define vibe_error(...) fprintf(stderr, "" __VA_ARGS__)
+#define vibe_print(fmt, ...) printf("" fmt, ##__VA_ARGS__)
+#define vibe_error(fmt, ...) fprintf(stderr, "" fmt, ##__VA_ARGS__)
 #endif


### PR DESCRIPTION
Hardened the `vibe_print` and `vibe_error` macros in `vibe_io.h` to prevent format string vulnerabilities by enforcing at compile-time that the first argument is a string literal. Documented the fix and the security learning in the project's security logs.

---
*PR created automatically by Jules for task [15066426890196802188](https://jules.google.com/task/15066426890196802188) started by @gtref*