### PR TITLE
🛡️ Sentinel: Fix NULL pointer dereference in vibe_regex_match

### DIFF
--- a/Jules/SENTINEL.md
+++ b/Jules/SENTINEL.md
@@ -120,6 +120,21 @@
 - Verified detection of `strncpy`, `syslog`, and `pickle.loads` in test files.
 - Confirmed `vibe_secure_memzero` correctly implementation in the header.
 
+## 2026-06-22 - Regex NULL Safety and Robustness
+
+### 🔍 Found
+- **NULL Pointer Dereference in Regex**: The `vibe_regex_match` function in `vibe_regex.h` lacked NULL pointer checks for its `pattern` and `text` arguments. This would lead to application crashes (Denial of Service) if NULL was passed to either argument.
+
+### 🎯 Impact
+- **Denial of Service**: Malicious or buggy code calling the regex library with unvalidated inputs could crash the entire application process.
+
+### 🔧 Fix
+- **Defensive Programming**: Added explicit NULL pointer checks at the entry of `vibe_regex_match` in `vibe/include/vibe_regex.h`. The function now returns `false` gracefully if either the pattern or the text is NULL.
+
+### ✅ Verification
+- Updated `tests/security_test.c` with new test cases covering NULL inputs for `vibe_regex_match`.
+- Confirmed that all security tests pass and no crashes occur when passing NULL to the regex engine.
+
 ---
 
 ## Project Navigation

--- a/tests/security_test.c
+++ b/tests/security_test.c
@@ -3,14 +3,21 @@
 #include <vibe_string.h>
 #include <vibe_test.h>
 #include <vibe_json.h>
+#include <vibe_regex.h>
 
 void test_null_checks() {
     // These should not crash
-    vibe_str_eq(NULL, "test");
-    vibe_str_eq("test", NULL);
-    vibe_str_eq(NULL, NULL);
-    vibe_json_new_string(NULL);
-    vibe_json_print(NULL);
+    VIBE_ASSERT(vibe_str_eq(NULL, "test") == false);
+    VIBE_ASSERT(vibe_str_eq("test", NULL) == false);
+    VIBE_ASSERT(vibe_str_eq(NULL, NULL) == true);
+    VIBE_ASSERT(vibe_json_new_string(NULL) == NULL);
+    vibe_json_print(NULL); // Should print "null"
+
+    // Test regex NULL checks
+    VIBE_ASSERT(vibe_regex_match(NULL, "test") == false);
+    VIBE_ASSERT(vibe_regex_match(".*", NULL) == false);
+    VIBE_ASSERT(vibe_regex_match(NULL, NULL) == false);
+
     VIBE_ASSERT(true); // If we reached here, no crash
 }
 

--- a/vibe/include/vibe_regex.h
+++ b/vibe/include/vibe_regex.h
@@ -9,6 +9,7 @@
  * vibe_regex_match - Check if a string matches a pattern
  */
 static inline bool vibe_regex_match(const char* pattern, const char* text) {
+    if (!pattern || !text) return false;
     regex_t regex;
     int reti;
     bool result = false;


### PR DESCRIPTION
This PR addresses a security vulnerability where `vibe_regex_match` would crash if passed NULL for either the `pattern` or `text` arguments.

🚨 Severity: MEDIUM (Denial of Service)
💡 Vulnerability: NULL pointer dereference in `regcomp` or `regexec`.
🎯 Impact: Application crash if unvalidated input is passed to the regex utility.
🔧 Fix: Added explicit NULL checks at the start of `vibe_regex_match` to return `false` early.
✅ Verification: Added NULL-check assertions to `tests/security_test.c`. All tests passed.

---
*PR created automatically by Jules for task [3739324625497817349](https://jules.google.com/task/3739324625497817349) started by @gtref*