### PR TITLE
🛡️ Sentinel: Hardened thread pool with job queue limit

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -73,7 +73,7 @@
 **Learning:** Directory traversal logic must explicitly decide whether to follow symlinks to avoid infinite loops or path traversal. Concurrency primitives must always include lifecycle management (destruction) and input validation to prevent resource exhaustion or DoS.
 **Prevention:** Use `follow_symlinks=False` in directory scanning unless symlinks are explicitly required. Ensure all allocated resources (threads, memory) have a clear path to being freed.
 
-## 2026-06-25 - [1.5.5] - Resource Exhaustion and Race Conditions in Concurrency Primitives
-**Vulnerability:** Unbounded thread creation and unchecked job queuing during shutdown in the thread pool.
-**Learning:** Concurrency primitives must always enforce resource limits and provide explicit lifecycle state management (e.g., a shutdown flag) that is checked during all entry points (like adding a job) while holding the necessary synchronization locks.
-**Prevention:** Always implement an upper bound on threads/workers and verify the current operational state of a resource manager before allowing new work to be queued.
+## 2026-06-25 - [1.5.5] - Comprehensive Resource Hardening in Concurrency Primitives
+**Vulnerability:** Unbounded thread creation, unbounded job queuing, and unchecked job queuing during shutdown in the thread pool.
+**Learning:** Concurrency primitives must enforce limits on ALL resources they manage (both threads and memory/queue size) to prevent Denial of Service. Lifecycle state must be checked atomically at all entry points to ensure consistent behavior and prevent leaks.
+**Prevention:** Implement strict upper bounds on both worker counts and queue depths. Always verify the current operational state (e.g., shutdown status) while holding the necessary synchronization locks before accepting new work.

--- a/Jules/SENTINEL.md
+++ b/Jules/SENTINEL.md
@@ -1,21 +1,23 @@
 # Sentinel Security Log 🛡️
 
-## 2026-06-25 - [1.5.5] - Thread Pool Overflow and Shutdown Safety
+## 2026-06-25 - [1.5.5] - Thread Pool Resource Hardening (Threads and Jobs)
 
 ### 🔍 Found
-- **Resource Exhaustion (DoS)**: `vibe_thread_pool_create` lacked an upper bound on the number of threads, allowing an attacker or a buggy configuration to exhaust system resources (threads, memory) or potentially cause integer overflow in allocation size.
-- **Race Condition & Memory Leak**: `vibe_thread_pool_add_job` did not check the `shutdown` flag. If a job was added while the pool was being destroyed (after `shutdown` was set but before queue cleanup), the job would be added to the queue and potentially never processed or freed, leading to memory leaks and unpredictable behavior during destruction.
+- **Resource Exhaustion (DoS) - Threads**: `vibe_thread_pool_create` lacked an upper bound on the number of threads, allowing system resource exhaustion or potential integer overflow in allocation size.
+- **Resource Exhaustion (DoS) - Jobs**: The thread pool lacked a limit on the number of queued jobs. An attacker could flood the system with jobs, leading to unbounded memory consumption and application crashes.
+- **Race Condition & Memory Leak**: `vibe_thread_pool_add_job` did not check the `shutdown` flag. If a job was added while the pool was being destroyed, it could lead to memory leaks and unpredictable behavior.
 
 ### 🎯 Impact
-- **Denial of Service**: Excessive thread creation can crash the application or the entire system.
-- **Unstable Shutdown**: Race conditions during shutdown can lead to crashes or resource leakage in long-running processes.
+- **Denial of Service**: Excessive thread creation or an unbounded job queue can crash the application or the entire system via OOM (Out Of Memory).
+- **Unstable Shutdown**: Race conditions during shutdown can lead to crashes or resource leakage.
 
 ### 🔧 Fix
 - **Thread Limiting**: Enforced a maximum of 1024 threads in `vibe_thread_pool_create`.
-- **Shutdown Rejection**: Added a check for `pool->shutdown` in `vibe_thread_pool_add_job` while holding the mutex; jobs are now rejected and their memory is immediately freed if the pool is shutting down.
+- **Job Queue Limiting**: Implemented a `max_queue_size` (default 65536) in the thread pool and enforced it in `vibe_thread_pool_add_job`.
+- **Shutdown & Limit Rejection**: Updated `vibe_thread_pool_add_job` to reject and free jobs if the pool is shutting down OR if the queue is full.
 
 ### ✅ Verification
-- Created `tests/test_thread_pool_security.c` to verify that oversized pool creation is rejected and that jobs are correctly rejected during shutdown.
+- Enhanced `tests/test_thread_pool_security.c` to verify that oversized pool creation is rejected, jobs are rejected during shutdown, and the job queue limit is correctly enforced.
 - Confirmed all security and functional tests pass.
 
 ## 2026-06-22 - [1.5.3] - Security Auditor Refinement and Suppression Support

--- a/tests/test_thread_pool_security.c
+++ b/tests/test_thread_pool_security.c
@@ -31,6 +31,19 @@ int main() {
     vibe_thread_pool_add_job(pool, empty_job, NULL);
     VIBE_ASSERT(pool->queue_size == 0); // Job should have been rejected and freed
 
+    // Test 4: Queue limit
+    pthread_mutex_lock(&(pool->lock));
+    pool->shutdown = false; // Re-enable for this test
+    pool->max_queue_size = 2; // Set a small limit
+    pthread_mutex_unlock(&(pool->lock));
+
+    vibe_thread_pool_add_job(pool, empty_job, NULL);
+    vibe_thread_pool_add_job(pool, empty_job, NULL);
+    VIBE_ASSERT(pool->queue_size == 2);
+
+    vibe_thread_pool_add_job(pool, empty_job, NULL); // Should be rejected
+    VIBE_ASSERT(pool->queue_size == 2);
+
     // Cleanup (note: destroy expects threads to be joinable, but here they are still running)
     // To safely destroy after our manual shutdown trigger, we need to signal workers
     pthread_mutex_lock(&(pool->lock));

--- a/vibe/include/vibe_thread_pool.h
+++ b/vibe/include/vibe_thread_pool.h
@@ -24,6 +24,7 @@ typedef struct {
     vibe_job_t* queue_tail; // BOLT: Tail pointer for O(1) job insertion
     int thread_count;
     int queue_size;
+    int max_queue_size;
     bool shutdown;
 } vibe_thread_pool_t;
 
@@ -60,6 +61,7 @@ static inline vibe_thread_pool_t* vibe_thread_pool_create(int num_threads) {
 
     pool->thread_count = num_threads;
     pool->queue_size = 0;
+    pool->max_queue_size = 65536; // Sentinel: Default job queue limit to prevent DoS
     pool->queue_head = NULL;
     pool->queue_tail = NULL; // BOLT: Initialize tail pointer
     pool->shutdown = false;
@@ -116,8 +118,8 @@ static inline void vibe_thread_pool_add_job(vibe_thread_pool_t* pool, void (*fun
     job->next = NULL;
 
     pthread_mutex_lock(&(pool->lock));
-    // Sentinel: Reject new jobs if the pool is shutting down to prevent resource leakage/race conditions
-    if (pool->shutdown) {
+    // Sentinel: Reject new jobs if the pool is shutting down or queue is full to prevent resource leakage/DoS
+    if (pool->shutdown || pool->queue_size >= pool->max_queue_size) {
         pthread_mutex_unlock(&(pool->lock));
         free(job);
         return;


### PR DESCRIPTION
Identified a potential Denial of Service (DoS) vulnerability in the thread pool where an unbounded job queue could lead to memory exhaustion. Implemented a job queue limit (default 65536) and ensured that jobs are rejected and freed if the limit is reached or if the pool is shutting down. Verified the fix with new security test cases and updated the security documentation.

---
*PR created automatically by Jules for task [9730272037882252383](https://jules.google.com/task/9730272037882252383) started by @gtref*