### PR TITLE
🛡️ Sentinel: Harden constant-time comparisons and JSON printing

### DIFF
--- a/Jules/SENTINEL.md
+++ b/Jules/SENTINEL.md
@@ -197,6 +197,27 @@
 - Confirmed `vibe_thread_pool_destroy` correctly cleans up all threads and memory in `tests/test_thread_pool_functional.c`.
 - Verified all compiler tests and security audits pass with the new symlink restrictions.
 
+## 2026-06-26 - [1.5.6] - Constant-time Comparisons and JSON Depth Hardening
+
+### 🔍 Found
+- **Side-Channel Vulnerability (Timing Attack)**: `vibe_str_eq_constant_time` used `strlen()` to calculate lengths before comparison. This leaked the lengths of secret strings via timing side-channels, as `strlen`'s execution time depends on the null terminator's position.
+- **Denial of Service (DoS) - Stack Overflow**: `vibe_json_print` used unbounded recursion for nested JSON objects and arrays. An attacker could provide a deeply nested JSON structure to cause a stack overflow and crash the application.
+- **Audit Tool False Positives**: Safe uses of `printf` in `vibe_json.h` were being flagged by the security auditor.
+
+### 🎯 Impact
+- **Information Leakage**: Secret lengths could be recovered by an attacker.
+- **Application Availability**: Stack exhaustion leads to immediate crashes.
+- **Security Fatigue**: False positives in audit tools can mask real issues.
+
+### 🔧 Fix
+- **Safe Comparison**: Refactored `vibe_str_eq_constant_time` to use a single-pass loop without `strlen()`, minimizing length-based branching.
+- **Recursion Depth Limit**: Implemented a `VIBE_JSON_MAX_DEPTH` (128) limit in `vibe_json_print`. If exceeded, the printer outputs a placeholder instead of recursing deeper.
+- **Auditor Suppression**: Added `// nosec` to safe `printf` calls in the library.
+
+### ✅ Verification
+- Updated `tests/security_test.c` with more edge cases for constant-time string comparison.
+- Ran the full test suite and security audit; all tests passed and the library is now cleaner in the audit output.
+
 ---
 
 ## Project Navigation

--- a/tests/security_test.c
+++ b/tests/security_test.c
@@ -26,6 +26,9 @@ void test_constant_time_eq() {
     VIBE_ASSERT(vibe_str_eq_constant_time("test", "fail") == false);
     VIBE_ASSERT(vibe_str_eq_constant_time("test", "test1") == false);
     VIBE_ASSERT(vibe_str_eq_constant_time("test1", "test") == false);
+    VIBE_ASSERT(vibe_str_eq_constant_time("", "") == true);
+    VIBE_ASSERT(vibe_str_eq_constant_time("a", "a") == true);
+    VIBE_ASSERT(vibe_str_eq_constant_time("a", "b") == false);
     VIBE_ASSERT(vibe_str_eq_constant_time(NULL, NULL) == true);
     VIBE_ASSERT(vibe_str_eq_constant_time(NULL, "test") == false);
 }

--- a/vibe/include/vibe_json.h
+++ b/vibe/include/vibe_json.h
@@ -100,8 +100,17 @@ static inline void _vibe_json_print_escaped(const char* s) {
     putchar('\"');
 }
 
-static inline void vibe_json_print(vibe_json_value_t* v) {
+#ifndef VIBE_JSON_MAX_DEPTH
+#define VIBE_JSON_MAX_DEPTH 128
+#endif
+
+static inline void _vibe_json_print_recursive(vibe_json_value_t* v, int depth) {
     if (!v) { fputs("null", stdout); return; }
+    if (depth > VIBE_JSON_MAX_DEPTH) {
+        fputs("\"<max depth reached>\"", stdout);
+        return;
+    }
+
     switch(v->type) {
         case VIBE_JSON_NULL: fputs("null", stdout); break;
         case VIBE_JSON_BOOL: fputs(v->value.boolean ? "true" : "false", stdout); break;
@@ -114,9 +123,9 @@ static inline void vibe_json_print(vibe_json_value_t* v) {
             // BOLT: Fast path for integers to avoid slow %g formatter (~5x speedup)
             // Checks if number is an integer and fits within a safe 64-bit range
             else if (n >= -9e18 && n <= 9e18 && n == (long long)n) {
-                printf("%lld", (long long)n);
+                printf("%lld", (long long)n); // nosec
             } else {
-                printf("%g", n);
+                printf("%g", n); // nosec
             }
             break;
         }
@@ -127,10 +136,10 @@ static inline void vibe_json_print(vibe_json_value_t* v) {
             // BOLT: Optimized loop to remove conditional branch from hot path
             if (v->value.array.count > 0) {
                 for (size_t i = 0; i < v->value.array.count - 1; i++) {
-                    vibe_json_print(v->value.array.elements[i]);
+                    _vibe_json_print_recursive(v->value.array.elements[i], depth + 1);
                     putchar(',');
                 }
-                vibe_json_print(v->value.array.elements[v->value.array.count - 1]);
+                _vibe_json_print_recursive(v->value.array.elements[v->value.array.count - 1], depth + 1);
             }
             putchar(']');
             break;
@@ -141,17 +150,21 @@ static inline void vibe_json_print(vibe_json_value_t* v) {
                 for (size_t i = 0; i < v->value.object.count - 1; i++) {
                     _vibe_json_print_escaped(v->value.object.keys[i]);
                     putchar(':');
-                    vibe_json_print(v->value.object.values[i]);
+                    _vibe_json_print_recursive(v->value.object.values[i], depth + 1);
                     putchar(',');
                 }
                 _vibe_json_print_escaped(v->value.object.keys[v->value.object.count - 1]);
                 putchar(':');
-                vibe_json_print(v->value.object.values[v->value.object.count - 1]);
+                _vibe_json_print_recursive(v->value.object.values[v->value.object.count - 1], depth + 1);
             }
             putchar('}');
             break;
         default: fputs("???", stdout);
     }
+}
+
+static inline void vibe_json_print(vibe_json_value_t* v) {
+    _vibe_json_print_recursive(v, 0);
 }
 
 #endif

--- a/vibe/include/vibe_string.h
+++ b/vibe/include/vibe_string.h
@@ -12,14 +12,22 @@ static inline bool vibe_str_eq(const char* s1, const char* s2) {
  */
 static inline bool vibe_str_eq_constant_time(const char* s1, const char* s2) {
     if (!s1 || !s2) return s1 == s2;
-    size_t len1 = strlen(s1);
-    size_t len2 = strlen(s2);
-    int result = (len1 != len2);
-    size_t compare_len = len1 < len2 ? len1 : len2;
-    for (size_t i = 0; i < compare_len; i++) {
-        result |= s1[i] ^ s2[i];
+    const unsigned char* p1 = (const unsigned char*)s1;
+    const unsigned char* p2 = (const unsigned char*)s2;
+    unsigned char result = 0;
+    size_t i = 0;
+
+    // Single-pass comparison to avoid length-leaking strlen calls.
+    // For strings of equal length, this loop always runs for the full length plus the null terminator.
+    while (1) {
+        unsigned char c1 = p1[i];
+        unsigned char c2 = p2[i];
+        result |= (c1 ^ c2);
+        if (c1 == '\0' || c2 == '\0') break;
+        i++;
     }
-    return result == 0;
+
+    return result == 0 && p1[i] == '\0' && p2[i] == '\0';
 }
 
 #endif


### PR DESCRIPTION
This PR addresses two security concerns in the core library:
1. **Timing Attack Mitigation**: Refactored `vibe_str_eq_constant_time` in `vibe_string.h` to use a single-pass loop, eliminating length-leaking `strlen` calls.
2. **DoS Protection**: Added a recursion depth limit (`VIBE_JSON_MAX_DEPTH`) to `vibe_json_print` in `vibe_json.h` to prevent stack exhaustion from maliciously nested JSON.

Additionally, it suppresses audit false positives for safe `printf` usage in the JSON library.

---
*PR created automatically by Jules for task [16640407002298849541](https://jules.google.com/task/16640407002298849541) started by @gtref*